### PR TITLE
docs: expand README and update license

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2025 KenB-Good
+Copyright (c) 2025 WeirdDucks Studio
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/README.md
+++ b/README.md
@@ -1,2 +1,48 @@
-# streamjelly
-Jellyfin overlay for OBS — NOW PLAYING with album art, progress bar, and live updates.
+# StreamJelly — Jellyfin Overlay for OBS (Now Playing)
+
+**StreamJelly** is a self-hosted **Jellyfin overlay for OBS** that shows **NOW PLAYING** with album art, title/artist, and a live progress bar.  
+_"New Neon Edition — Your Jellyfin tracks, your OBS overlay."_
+
+## Quick Start (Docker)
+```bash
+git clone https://github.com/YOURORG/streamjelly.git
+cd streamjelly
+cp server/.env.example server/.env   # set JF_BASE, JF_TOKEN, JF_USER
+sudo docker compose up -d --build
+```
+
+OBS Browser Source → http://<server-ip>:8080/overlay  
+Admin UI → http://<server-ip>:8080/admin
+
+## Caddy (Auto-TLS)
+```bash
+sudo apt-get install -y caddy
+sudo cp caddy/Caddyfile.sample /etc/caddy/Caddyfile
+# edit domain in /etc/caddy/Caddyfile
+sudo systemctl reload caddy
+# Use: https://overlay.yourdomain.tld/overlay in OBS
+```
+
+## Env Vars (server/.env)
+```
+PORT=8080
+JF_BASE=https://YOUR-JELLYFIN-URL
+JF_TOKEN=YOUR_API_KEY
+JF_USER=your_username
+JF_CLIENT=Jellyfin Media Player
+JF_DEVICE=
+POLL_MS=1200
+THEME_ACCENT=#ff3b30
+THEME_ACCENT2=#ff6b6b
+THEME_ACCENT3=#ff9a8b
+LABEL_NOW=NOW PLAYING
+LABEL_PAUSE=PAUSED
+```
+
+## How it works
+
+Server polls Jellyfin `/Sessions`, broadcasts updates via SSE; the overlay page renders art/title/artist/progress. Secrets never touch OBS.
+
+## License
+
+MIT


### PR DESCRIPTION
## Summary
- replace placeholder README with detailed Jellyfin overlay instructions
- update license holder to WeirdDucks Studio

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c5cbde5d2c83268ce17a00e93e359a