### PR TITLE
Append query string to overlay API calls

### DIFF
--- a/server/public/overlay.html
+++ b/server/public/overlay.html
@@ -42,14 +42,15 @@
   function animate(t){ if(!paused && runtimeSec>0){ if(lastT) positionSec+=(t-lastT)/1000; positionSec=Math.min(positionSec,runtimeSec); paint(); } lastT=t; requestAnimationFrame(animate); }
   requestAnimationFrame(animate);
 
+  const append=u=>u+location.search;
   async function loadTheme(){ try{
-    const t=await (await fetch('/api/config',{cache:'no-store'})).json();
+    const t=await (await fetch(append('/api/config'),{cache:'no-store'})).json();
     document.documentElement.style.setProperty('--accent',t.accent||'#ff3b30');
     document.documentElement.style.setProperty('--accent2',t.accent2||'#ff6b6b');
     document.documentElement.style.setProperty('--accent3',t.accent3||'#ff9a8b');
   }catch{} } loadTheme();
 
-  const es=new EventSource('/api/nowplaying/stream');
+  const es=new EventSource('/api/nowplaying/stream'+location.search);
   es.onmessage=(e)=>{ try{
     const {type,payload}=JSON.parse(e.data);
     if(type==='nowplaying'){


### PR DESCRIPTION
## Summary
- support query parameters in overlay's now-playing EventSource
- include query string for theme config fetch and provide helper for future requests

## Testing
- `npm test --prefix server` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9ee13788326a1fc5144c367596b