### PR TITLE
docs: document overlay user restrictions

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,12 @@ THEME_ACCENT2=#ff6b6b
 THEME_ACCENT3=#ff9a8b
 LABEL_NOW=NOW PLAYING
 LABEL_PAUSE=PAUSED
+JF_USERS_ALLOW=kenbee
+OVERLAY_SIGNING_KEY=
 ```
+
+* `JF_USERS_ALLOW` — comma-separated Jellyfin usernames allowed to use the overlay.
+* `OVERLAY_SIGNING_KEY` — optional HMAC key; if set, URLs must include `sig=HMAC_SHA256(user,key)`.
 
 ## How it works
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -14,3 +14,9 @@ THEME_ACCENT2=#ff6b6b
 THEME_ACCENT3=#ff9a8b
 LABEL_NOW=NOW PLAYING
 LABEL_PAUSE=PAUSED
+
+# Comma-separated Jellyfin usernames allowed to use the overlay
+JF_USERS_ALLOW=kenbee
+
+# Optional HMAC key; if set, URLs must include sig=HMAC_SHA256(user,key)
+OVERLAY_SIGNING_KEY=


### PR DESCRIPTION
## Summary
- add JF_USERS_ALLOW and OVERLAY_SIGNING_KEY to server/.env.example
- document overlay access and signing options in README

## Testing
- `npm test` (fails: Missing script "test")

------
https://chatgpt.com/codex/tasks/task_e_68c5d9f0683c8326aa2c7d728b4cc4dd