### PR TITLE
docs: update usage instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,17 @@
 # StreamJelly — Jellyfin Overlay for OBS (Now Playing)
 
-**StreamJelly** is a self-hosted **Jellyfin overlay for OBS** that shows **NOW PLAYING** with album art, title/artist, and a live progress bar.  
+**StreamJelly** is a self-hosted **Jellyfin overlay for OBS** that shows **NOW PLAYING** with album art, title/artist, and a live progress bar.
 _"New Neon Edition — Your Jellyfin tracks, your OBS overlay."_
 
-## Quick Start (Docker)
+## For StreamJelly community members
+
+In OBS Browser Source, use `https://overlay.weirdducks.site/overlay?user=<yourname>` (width 820, height 220).
+
+Some links may include `&sig=` and should be copied intact.
+
+## For creators/self-hosters
+
+### Quick Start (Docker)
 ```bash
 git clone https://github.com/YOURORG/streamjelly.git
 cd streamjelly
@@ -14,6 +22,21 @@ sudo docker compose up -d --build
 OBS Browser Source → http://<server-ip>:8080/overlay
 
 Admin UI → http://<server-ip>:8080/admin
+
+### systemd (optional, no Docker)
+```bash
+curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
+sudo apt-get install -y nodejs git
+cd server && npm ci && cd ..
+sudo rsync -a . /opt/streamjelly/
+sudo cp systemd/streamjelly.service /etc/systemd/system/
+sudo systemctl daemon-reload
+sudo systemctl enable --now streamjelly
+```
+
+## Why StreamJelly
+
+StreamJelly delivers DMCA-safe, Jellyfin-backed overlays so creators can show now playing info without risking takedowns.
 
 ## Caddy (Auto-TLS)
 ```bash
@@ -43,36 +66,6 @@ LABEL_PAUSE=PAUSED
 ## How it works
 
 Server polls Jellyfin `/Sessions`, broadcasts updates via SSE; the overlay page renders art/title/artist/progress. Secrets never touch OBS.
-
-## Build & Run
-
-### Docker (recommended)
-```bash
-cp server/.env.example server/.env
-# edit server/.env: set JF_BASE, JF_TOKEN, JF_USER
-sudo docker compose up -d --build
-curl -fsSL http://localhost:8080/healthz
-```
-
-### systemd (optional, no Docker)
-```bash
-curl -fsSL https://deb.nodesource.com/setup_20.x | sudo -E bash -
-sudo apt-get install -y nodejs git
-cd server && npm ci && cd ..
-sudo rsync -a . /opt/streamjelly/
-sudo cp systemd/streamjelly.service /etc/systemd/system/
-sudo systemctl daemon-reload
-sudo systemctl enable --now streamjelly
-```
-
-### Caddy (preferred reverse proxy)
-```bash
-sudo apt-get install -y caddy
-sudo cp caddy/Caddyfile.sample /etc/caddy/Caddyfile
-# edit overlay.yourdomain.tld -> your domain (DNS must point here)
-sudo systemctl reload caddy
-# OBS URL becomes: https://overlay.yourdomain.tld/overlay
-```
 
 ## License
 


### PR DESCRIPTION
## Summary
- document community overlay URL and `&sig=` note
- add creators/self-hosters setup guide
- highlight DMCA-safe Jellyfin-backed overlays

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9f2636c8326939673bf8fc7023b