### PR TITLE
feat: add per-user overlays with optional signing

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,8 @@ cp server/.env.example server/.env   # set JF_BASE, JF_TOKEN, JF_USER
 sudo docker compose up -d --build
 ```
 
-OBS Browser Source → http://<server-ip>:8080/overlay
+OBS Browser Source → http://<server-ip>:8080/<your_user>/overlay
+# If SIGN_KEY is set, append ?sig=$(printf <your_user> | openssl dgst -sha256 -hmac "$SIGN_KEY" -binary | xxd -p -c256)
 
 Admin UI → http://<server-ip>:8080/admin
 
@@ -21,7 +22,7 @@ sudo apt-get install -y caddy
 sudo cp caddy/Caddyfile.sample /etc/caddy/Caddyfile
 # edit domain in /etc/caddy/Caddyfile
 sudo systemctl reload caddy
-# Use: https://overlay.yourdomain.tld/overlay in OBS
+# Use: https://overlay.yourdomain.tld/<your_user>/overlay?sig=... in OBS
 ```
 
 ## Env Vars (server/.env)
@@ -29,10 +30,11 @@ sudo systemctl reload caddy
 PORT=8080
 JF_BASE=https://YOUR-JELLYFIN-URL
 JF_TOKEN=YOUR_API_KEY
-JF_USER=your_username
+JF_USER=your_username            # optional; per-user URLs override
 JF_CLIENT=Jellyfin Media Player
 JF_DEVICE=
 POLL_MS=1200
+SIGN_KEY=
 THEME_ACCENT=#ff3b30
 THEME_ACCENT2=#ff6b6b
 THEME_ACCENT3=#ff9a8b
@@ -71,7 +73,7 @@ sudo apt-get install -y caddy
 sudo cp caddy/Caddyfile.sample /etc/caddy/Caddyfile
 # edit overlay.yourdomain.tld -> your domain (DNS must point here)
 sudo systemctl reload caddy
-# OBS URL becomes: https://overlay.yourdomain.tld/overlay
+# OBS URL becomes: https://overlay.yourdomain.tld/<your_user>/overlay?sig=...
 ```
 
 ## License

--- a/caddy/Caddyfile.sample
+++ b/caddy/Caddyfile.sample
@@ -6,4 +6,6 @@ overlay.yourdomain.tld {
     Cache-Control "no-store"
   }
   reverse_proxy 127.0.0.1:8080
+  # Example OBS URL:
+  #   https://overlay.yourdomain.tld/<user>/overlay?sig=...
 }

--- a/scripts/bootstrap_repo.sh
+++ b/scripts/bootstrap_repo.sh
@@ -30,7 +30,7 @@ mkdir -p .
 cat <<'EOF' > README.md
 # StreamJelly — Jellyfin Overlay for OBS (Now Playing)
 
-**StreamJelly** is a self-hosted **Jellyfin overlay for OBS** that shows **NOW PLAYING** with album art, title/artist, and a live progress bar.  
+**StreamJelly** is a self-hosted **Jellyfin overlay for OBS** that shows **NOW PLAYING** with album art, title/artist, and a live progress bar.
 _"New Neon Edition — Your Jellyfin tracks, your OBS overlay."_
 
 ## Quick Start (Docker)
@@ -41,7 +41,8 @@ cp server/.env.example server/.env   # set JF_BASE, JF_TOKEN, JF_USER
 sudo docker compose up -d --build
 ```
 
-OBS Browser Source → http://<server-ip>:8080/overlay
+OBS Browser Source → http://<server-ip>:8080/<your_user>/overlay
+# If SIGN_KEY is set, append ?sig=$(printf <your_user> | openssl dgst -sha256 -hmac "$SIGN_KEY" -binary | xxd -p -c256)
 
 Admin UI → http://<server-ip>:8080/admin
 
@@ -51,7 +52,7 @@ sudo apt-get install -y caddy
 sudo cp caddy/Caddyfile.sample /etc/caddy/Caddyfile
 # edit domain in /etc/caddy/Caddyfile
 sudo systemctl reload caddy
-# Use: https://overlay.yourdomain.tld/overlay in OBS
+# Use: https://overlay.yourdomain.tld/<your_user>/overlay?sig=... in OBS
 ```
 
 ## Env Vars (server/.env)
@@ -59,10 +60,11 @@ sudo systemctl reload caddy
 PORT=8080
 JF_BASE=https://YOUR-JELLYFIN-URL
 JF_TOKEN=YOUR_API_KEY
-JF_USER=your_username
+JF_USER=your_username            # optional; per-user URLs override
 JF_CLIENT=Jellyfin Media Player
 JF_DEVICE=
 POLL_MS=1200
+SIGN_KEY=
 THEME_ACCENT=#ff3b30
 THEME_ACCENT2=#ff6b6b
 THEME_ACCENT3=#ff9a8b
@@ -143,10 +145,13 @@ PORT=8080
 # Jellyfin connection (server-side only)
 JF_BASE=https://YOUR-JELLYFIN-URL
 JF_TOKEN=YOUR_API_KEY
-JF_USER=your_username
+JF_USER=your_username            # optional; overridden by per-user URLs
 JF_CLIENT=Jellyfin Media Player
 JF_DEVICE=
 POLL_MS=1200
+
+# Signed per-user URLs (optional)
+SIGN_KEY=
 
 # Theme: New Neon Edition
 THEME_ACCENT=#ff3b30
@@ -158,64 +163,66 @@ EOF
 
 mkdir -p server
 cat <<'EOF' > server/index.js
-import '"'"'dotenv/config'"'"';
-import express from '"'"'express'"'"';
-import { fetch } from '"'"'undici'"'"';
-import path from '"'"'node:path'"'"';
-import { setInterval as every } from '"'"'node:timers'"'"';
+import 'dotenv/config';
+import express from 'express';
+import { fetch } from 'undici';
+import path from 'node:path';
+import { setInterval as every } from 'node:timers';
+import { createHmac } from 'node:crypto';
 
 const app = express();
 app.use(express.json());
-app.use('"'"'/public'"'"', express.static(path.join(process.cwd(), '"'"'server'"'"', '"'"'public'"'"')));
+app.use('/public', express.static(path.join(process.cwd(), 'server', 'public')));
 
 /* ---- config ---- */
 const cfg = {
-  port: parseInt(process.env.PORT || '"'"'8080'"'"', 10),
+  port: parseInt(process.env.PORT || '8080', 10),
   jfBase: process.env.JF_BASE,
   jfToken: process.env.JF_TOKEN,
-  jfUser: (process.env.JF_USER || '"'"''"'"').toLowerCase(),
-  jfClient: process.env.JF_CLIENT || '"'"'Jellyfin Media Player'"'"',
-  jfDevice: process.env.JF_DEVICE || '"'"''"'"',
-  pollMs: parseInt(process.env.POLL_MS || '"'"'1200'"'"', 10),
+  jfUser: (process.env.JF_USER || '').toLowerCase(),
+  jfClient: process.env.JF_CLIENT || 'Jellyfin Media Player',
+  jfDevice: process.env.JF_DEVICE || '',
+  pollMs: parseInt(process.env.POLL_MS || '1200', 10),
+  signKey: process.env.SIGN_KEY || '',
   theme: {
-    accent: process.env.THEME_ACCENT || '"'"'#ff3b30'"'"',
-    accent2: process.env.THEME_ACCENT2 || '"'"'#ff6b6b'"'"',
-    accent3: process.env.THEME_ACCENT3 || '"'"'#ff9a8b'"'"',
-    labelNow: process.env.LABEL_NOW || '"'"'NOW PLAYING'"'"',
-    labelPause: process.env.LABEL_PAUSE || '"'"'PAUSED'"'"'
+    accent: process.env.THEME_ACCENT || '#ff3b30',
+    accent2: process.env.THEME_ACCENT2 || '#ff6b6b',
+    accent3: process.env.THEME_ACCENT3 || '#ff9a8b',
+    labelNow: process.env.LABEL_NOW || 'NOW PLAYING',
+    labelPause: process.env.LABEL_PAUSE || 'PAUSED'
   }
 };
 
 const headers = {
-  '"'"'Authorization'"'"': `MediaBrowser Client="StreamJelly", Device="Overlay-Server", DeviceId="streamjelly", Version="0.1", Token="${cfg.jfToken}"`,
-  '"'"'X-MediaBrowser-Token'"'"': cfg.jfToken,
-  '"'"'Accept'"'"': '"'"'application/json'"'"'
+  'Authorization': `MediaBrowser Client="StreamJelly", Device="Overlay-Server", DeviceId="streamjelly", Version="0.1", Token="${cfg.jfToken}"`,
+  'X-MediaBrowser-Token': cfg.jfToken,
+  'Accept': 'application/json'
 };
 
-const clients = new Set();
-let lastPayload = null;
+const clients = new Map(); // user -> Set<res>
+const lastPayload = new Map();
 
 /* ---- helpers ---- */
-async function fetchNowPlaying() {
-  const r = await fetch(`${cfg.jfBase}/Sessions?ActiveWithinSeconds=180`, { headers, cache: '"'"'no-store'"'"' });
+async function fetchNowPlaying(user) {
+  const r = await fetch(`${cfg.jfBase}/Sessions?ActiveWithinSeconds=180`, { headers, cache: 'no-store' });
   if (!r.ok) throw new Error(`Jellyfin HTTP ${r.status}`);
   const sessions = await r.json();
   const s = sessions.find(x =>
-    x?.UserName?.toLowerCase() === cfg.jfUser &&
+    x?.UserName?.toLowerCase() === user &&
     x?.Client === cfg.jfClient &&
     (!cfg.jfDevice || x?.DeviceName === cfg.jfDevice) &&
-    x?.NowPlayingItem?.MediaType === '"'"'Audio'"'"'
+    x?.NowPlayingItem?.MediaType === 'Audio'
   );
   if (!s) return null;
 
   const it = s.NowPlayingItem || {};
-  const title = it.Name || '"'"'Unknown'"'"';
-  const artist = it.AlbumArtist || (Array.isArray(it.Artists) ? it.Artists[0] : '"'"''"'"') || '"'"''"'"';
+  const title = it.Name || 'Unknown';
+  const artist = it.AlbumArtist || (Array.isArray(it.Artists) ? it.Artists[0] : '') || '';
   const artTag = it?.ImageTags?.Primary;
   const albumId = it?.AlbumId;
   const artUrl = artTag
     ? `${cfg.jfBase}/Items/${it.Id}/Images/Primary?tag=${artTag}&maxWidth=256&quality=85`
-    : (albumId ? `${cfg.jfBase}/Items/${albumId}/Images/Primary?maxWidth=256&quality=85` : '"'"''"'"');
+    : (albumId ? `${cfg.jfBase}/Items/${albumId}/Images/Primary?maxWidth=256&quality=85` : '');
 
   const runtimeSec = (it.RunTimeTicks ?? 0) / 1e7;
   const positionSec = (s.PlayState?.PositionTicks ?? 0) / 1e7;
@@ -223,63 +230,90 @@ async function fetchNowPlaying() {
 
   return { title, artist, artUrl, runtimeSec, positionSec, paused, ts: Date.now() };
 }
+function sign(u) {
+  return createHmac('sha256', cfg.signKey).update(u).digest('hex');
+}
 
-function broadcast(obj) {
+function resolveUser(req, res) {
+  const user = (req.params.user || cfg.jfUser || '').toLowerCase();
+  if (!user) { res.status(400).json({ error: 'user required' }); return null; }
+  if (cfg.signKey) {
+    const sig = String(req.query.sig || '');
+    if (sig !== sign(user)) { res.status(403).json({ error: 'bad signature' }); return null; }
+  }
+  return user;
+}
+
+function broadcast(user, obj) {
   const data = `data: ${JSON.stringify(obj)}\n\n`;
-  for (const res of clients) res.write(data);
+  const set = clients.get(user);
+  if (!set) return;
+  for (const res of set) res.write(data);
 }
 
 /* ---- polling & stream ---- */
 every(cfg.pollMs, async () => {
-  try {
-    const cur = await fetchNowPlaying();
-    const serialized = JSON.stringify(cur);
-    if (serialized !== lastPayload) {
-      lastPayload = serialized;
-      broadcast({ type: '"'"'nowplaying'"'"', payload: cur });
+  for (const user of clients.keys()) {
+    try {
+      const cur = await fetchNowPlaying(user);
+      const serialized = JSON.stringify(cur);
+      if (serialized !== lastPayload.get(user)) {
+        lastPayload.set(user, serialized);
+        broadcast(user, { type: 'nowplaying', payload: cur });
+      }
+    } catch (e) {
+      broadcast(user, { type: 'error', message: e.message });
     }
-  } catch (e) {
-    broadcast({ type: '"'"'error'"'"', message: e.message });
   }
 });
 
 /* ---- endpoints ---- */
-app.get('"'"'/api/nowplaying'"'"', async (_req, res) => {
-  try { res.json(await fetchNowPlaying()); }
+app.get(['/api/nowplaying', '/:user/api/nowplaying'], async (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
+  try { res.json(await fetchNowPlaying(user)); }
   catch (e) { res.status(500).json({ error: String(e) }); }
 });
 
-app.get('"'"'/api/nowplaying/stream'"'"', (req, res) => {
+app.get(['/api/nowplaying/stream', '/:user/api/nowplaying/stream'], (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
   res.set({
-    '"'"'Content-Type'"'"': '"'"'text/event-stream'"'"',
-    '"'"'Cache-Control'"'"': '"'"'no-cache'"'"',
-    '"'"'Connection'"'"': '"'"'keep-alive'"'"',
-    '"'"'Access-Control-Allow-Origin'"'"': '"'"'*'"'"'
+    'Content-Type': 'text/event-stream',
+    'Cache-Control': 'no-cache',
+    'Connection': 'keep-alive',
+    'Access-Control-Allow-Origin': '*'
   });
   res.flushHeaders();
-  res.write('"'"'retry: 1000\n\n'"'"');
-  clients.add(res);
-  req.on('"'"'close'"'"', () => clients.delete(res));
+  res.write('retry: 1000\n\n');
+  let set = clients.get(user);
+  if (!set) { set = new Set(); clients.set(user, set); }
+  set.add(res);
+  req.on('close', () => {
+    set.delete(res);
+    if (!set.size) { clients.delete(user); lastPayload.delete(user); }
+  });
 });
 
 /* theme config (no auth; recommend gating via Caddy) */
-app.get('"'"'/api/config'"'"', (_req, res) => res.json(cfg.theme));
-app.put('"'"'/api/config'"'"', (req, res) => {
+app.get(['/api/config', '/:user/api/config'], (_req, res) => res.json(cfg.theme));
+app.put(['/api/config', '/:user/api/config'], (req, res) => {
   const t = req.body || {};
   cfg.theme = { ...cfg.theme, ...t };
-  broadcast({ type: '"'"'theme'"'"', payload: cfg.theme });
+  // broadcast theme to all users
+  for (const u of clients.keys()) broadcast(u, { type: 'theme', payload: cfg.theme });
   res.json(cfg.theme);
 });
 
 /* health */
-app.get('"'"'/healthz'"'"', (_req, res) => res.json({ ok: true }));
+app.get('/healthz', (_req, res) => res.json({ ok: true }));
 
 /* pages */
-app.get('"'"'/overlay'"'"', (_req, res) =>
-  res.sendFile(path.join(process.cwd(), '"'"'server'"'"', '"'"'public'"'"', '"'"'overlay.html'"'"')));
+app.get(['/overlay', '/:user/overlay'], (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
+  res.sendFile(path.join(process.cwd(), 'server', 'public', 'overlay.html'));
+});
 
-app.get('"'"'/admin'"'"', (_req, res) =>
-  res.sendFile(path.join(process.cwd(), '"'"'server'"'"', '"'"'public'"'"', '"'"'admin.html'"'"')));
+app.get('/admin', (_req, res) =>
+  res.sendFile(path.join(process.cwd(), 'server', 'public', 'admin.html')));
 
 app.listen(cfg.port, () => {
   console.log(`StreamJelly listening on http://0.0.0.0:${cfg.port}`);
@@ -322,43 +356,44 @@ cat <<'EOF' > server/public/overlay.html
 </div>
 <div id="err"></div>
 <script>
-  const wrap=document.querySelector('"'"'#wrap'"'"'), err=document.querySelector('"'"'#err'"'"');
-  const img=document.querySelector('"'"'#art img'"'"'), titleEl=document.querySelector('"'"'#title'"'"'), artistEl=document.querySelector('"'"'#artist'"'"');
-  const fill=document.querySelector('"'"'#fill'"'"'), curEl=document.querySelector('"'"'#cur'"'"'), durEl=document.querySelector('"'"'#dur'"'"'), labelEl=document.querySelector('"'"'#label'"'"');
+  const wrap=document.querySelector('#wrap'), err=document.querySelector('#err');
+  const img=document.querySelector('#art img'), titleEl=document.querySelector('#title'), artistEl=document.querySelector('#artist');
+  const fill=document.querySelector('#fill'), curEl=document.querySelector('#cur'), durEl=document.querySelector('#dur'), labelEl=document.querySelector('#label');
 
   let runtimeSec=0, positionSec=0, paused=true, lastT=0;
-  const fmt=s=>{s=Math.max(0,Math.floor(s));const m=Math.floor(s/60),n=s%60;return `${m}:${n.toString().padStart(2,'"'"'0'"'"')}`;}
+  const fmt=s=>{s=Math.max(0,Math.floor(s));const m=Math.floor(s/60),n=s%60;return `${m}:${n.toString().padStart(2,'0')}`;}
   function paint(){ const pct=runtimeSec>0?Math.min(100,(positionSec/runtimeSec)*100):0; fill.style.width=`${pct}%`; curEl.textContent=fmt(positionSec); durEl.textContent=fmt(runtimeSec); }
   function animate(t){ if(!paused && runtimeSec>0){ if(lastT) positionSec+=(t-lastT)/1000; positionSec=Math.min(positionSec,runtimeSec); paint(); } lastT=t; requestAnimationFrame(animate); }
   requestAnimationFrame(animate);
 
+  const qs=location.search||'';
   async function loadTheme(){ try{
-    const t=await (await fetch('"'"'/api/config'"'"',{cache:'"'"'no-store'"'"'})).json();
-    document.documentElement.style.setProperty('"'"'--accent'"'"',t.accent||'"'"'#ff3b30'"'"');
-    document.documentElement.style.setProperty('"'"'--accent2'"'"',t.accent2||'"'"'#ff6b6b'"'"');
-    document.documentElement.style.setProperty('"'"'--accent3'"'"',t.accent3||'"'"'#ff9a8b'"'"');
+    const t=await (await fetch('api/config'+qs,{cache:'no-store'})).json();
+    document.documentElement.style.setProperty('--accent',t.accent||'#ff3b30');
+    document.documentElement.style.setProperty('--accent2',t.accent2||'#ff6b6b');
+    document.documentElement.style.setProperty('--accent3',t.accent3||'#ff9a8b');
   }catch{} } loadTheme();
 
-  const es=new EventSource('"'"'/api/nowplaying/stream'"'"');
+  const es=new EventSource('api/nowplaying/stream'+qs);
   es.onmessage=(e)=>{ try{
     const {type,payload}=JSON.parse(e.data);
-    if(type==='"'"'nowplaying'"'"'){
+    if(type==='nowplaying'){
       if(!payload){ wrap.style.opacity=0; return; }
-      titleEl.textContent=payload.title||'"'"'Unknown'"'"';
-      artistEl.textContent=payload.artist||'"'"''"'"';
+      titleEl.textContent=payload.title||'Unknown';
+      artistEl.textContent=payload.artist||'';
       if(payload.artUrl) img.src=payload.artUrl;
       runtimeSec=payload.runtimeSec||0; positionSec=payload.positionSec||0; paused=!!payload.paused;
-      labelEl.textContent = paused ? '"'"'PAUSED'"'"' : '"'"'NOW PLAYING'"'"';
-      paint(); wrap.style.opacity=1; err.textContent='"'"''"'"';
-    } else if(type==='"'"'theme'"'"'){
+      labelEl.textContent = paused ? 'PAUSED' : 'NOW PLAYING';
+      paint(); wrap.style.opacity=1; err.textContent='';
+    } else if(type==='theme'){
       const t=payload||{};
-      if(t.accent)  document.documentElement.style.setProperty('"'"'--accent'"'"', t.accent);
-      if(t.accent2) document.documentElement.style.setProperty('"'"'--accent2'"'"', t.accent2);
-      if(t.accent3) document.documentElement.style.setProperty('"'"'--accent3'"'"', t.accent3);
-      labelEl.textContent = paused ? (t.labelPause||'"'"'PAUSED'"'"') : (t.labelNow||'"'"'NOW PLAYING'"'"');
+      if(t.accent)  document.documentElement.style.setProperty('--accent', t.accent);
+      if(t.accent2) document.documentElement.style.setProperty('--accent2', t.accent2);
+      if(t.accent3) document.documentElement.style.setProperty('--accent3', t.accent3);
+      labelEl.textContent = paused ? (t.labelPause||'PAUSED') : (t.labelNow||'NOW PLAYING');
     }
-  }catch{ err.textContent='"'"'Stream parse error'"'"'; } };
-  es.onerror=()=>{ err.textContent='"'"'Stream disconnected'"'"'; wrap.style.opacity=0; };
+  }catch{ err.textContent='Stream parse error'; } };
+  es.onerror=()=>{ err.textContent='Stream disconnected'; wrap.style.opacity=0; };
 </script>
 EOF
 
@@ -433,6 +468,8 @@ overlay.yourdomain.tld {
     Cache-Control "no-store"
   }
   reverse_proxy 127.0.0.1:8080
+  # Example OBS URL:
+  #   https://overlay.yourdomain.tld/<user>/overlay?sig=...
 }
 EOF
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -3,10 +3,13 @@ PORT=8080
 # Jellyfin connection (server-side only)
 JF_BASE=https://YOUR-JELLYFIN-URL
 JF_TOKEN=YOUR_API_KEY
-JF_USER=your_username
+JF_USER=your_username            # optional; overridden by per-user URLs
 JF_CLIENT=Jellyfin Media Player
 JF_DEVICE=
 POLL_MS=1200
+
+# Signed per-user URLs (optional)
+SIGN_KEY=
 
 # Theme: New Neon Edition
 THEME_ACCENT=#ff3b30

--- a/server/index.js
+++ b/server/index.js
@@ -3,6 +3,7 @@ import express from 'express';
 import { fetch } from 'undici';
 import path from 'node:path';
 import { setInterval as every } from 'node:timers';
+import { createHmac } from 'node:crypto';
 
 const app = express();
 app.use(express.json());
@@ -17,6 +18,7 @@ const cfg = {
   jfClient: process.env.JF_CLIENT || 'Jellyfin Media Player',
   jfDevice: process.env.JF_DEVICE || '',
   pollMs: parseInt(process.env.POLL_MS || '1200', 10),
+  signKey: process.env.SIGN_KEY || '',
   theme: {
     accent: process.env.THEME_ACCENT || '#ff3b30',
     accent2: process.env.THEME_ACCENT2 || '#ff6b6b',
@@ -32,16 +34,16 @@ const headers = {
   'Accept': 'application/json'
 };
 
-const clients = new Set();
-let lastPayload = null;
+const clients = new Map(); // user -> Set<res>
+const lastPayload = new Map();
 
 /* ---- helpers ---- */
-async function fetchNowPlaying() {
+async function fetchNowPlaying(user) {
   const r = await fetch(`${cfg.jfBase}/Sessions?ActiveWithinSeconds=180`, { headers, cache: 'no-store' });
   if (!r.ok) throw new Error(`Jellyfin HTTP ${r.status}`);
   const sessions = await r.json();
   const s = sessions.find(x =>
-    x?.UserName?.toLowerCase() === cfg.jfUser &&
+    x?.UserName?.toLowerCase() === user &&
     x?.Client === cfg.jfClient &&
     (!cfg.jfDevice || x?.DeviceName === cfg.jfDevice) &&
     x?.NowPlayingItem?.MediaType === 'Audio'
@@ -63,33 +65,52 @@ async function fetchNowPlaying() {
 
   return { title, artist, artUrl, runtimeSec, positionSec, paused, ts: Date.now() };
 }
+function sign(u) {
+  return createHmac('sha256', cfg.signKey).update(u).digest('hex');
+}
 
-function broadcast(obj) {
+function resolveUser(req, res) {
+  const user = (req.params.user || cfg.jfUser || '').toLowerCase();
+  if (!user) { res.status(400).json({ error: 'user required' }); return null; }
+  if (cfg.signKey) {
+    const sig = String(req.query.sig || '');
+    if (sig !== sign(user)) { res.status(403).json({ error: 'bad signature' }); return null; }
+  }
+  return user;
+}
+
+function broadcast(user, obj) {
   const data = `data: ${JSON.stringify(obj)}\n\n`;
-  for (const res of clients) res.write(data);
+  const set = clients.get(user);
+  if (!set) return;
+  for (const res of set) res.write(data);
 }
 
 /* ---- polling & stream ---- */
 every(cfg.pollMs, async () => {
-  try {
-    const cur = await fetchNowPlaying();
-    const serialized = JSON.stringify(cur);
-    if (serialized !== lastPayload) {
-      lastPayload = serialized;
-      broadcast({ type: 'nowplaying', payload: cur });
+  for (const user of clients.keys()) {
+    try {
+      const cur = await fetchNowPlaying(user);
+      const serialized = JSON.stringify(cur);
+      if (serialized !== lastPayload.get(user)) {
+        lastPayload.set(user, serialized);
+        broadcast(user, { type: 'nowplaying', payload: cur });
+      }
+    } catch (e) {
+      broadcast(user, { type: 'error', message: e.message });
     }
-  } catch (e) {
-    broadcast({ type: 'error', message: e.message });
   }
 });
 
 /* ---- endpoints ---- */
-app.get('/api/nowplaying', async (_req, res) => {
-  try { res.json(await fetchNowPlaying()); }
+app.get(['/api/nowplaying', '/:user/api/nowplaying'], async (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
+  try { res.json(await fetchNowPlaying(user)); }
   catch (e) { res.status(500).json({ error: String(e) }); }
 });
 
-app.get('/api/nowplaying/stream', (req, res) => {
+app.get(['/api/nowplaying/stream', '/:user/api/nowplaying/stream'], (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
   res.set({
     'Content-Type': 'text/event-stream',
     'Cache-Control': 'no-cache',
@@ -98,16 +119,22 @@ app.get('/api/nowplaying/stream', (req, res) => {
   });
   res.flushHeaders();
   res.write('retry: 1000\n\n');
-  clients.add(res);
-  req.on('close', () => clients.delete(res));
+  let set = clients.get(user);
+  if (!set) { set = new Set(); clients.set(user, set); }
+  set.add(res);
+  req.on('close', () => {
+    set.delete(res);
+    if (!set.size) { clients.delete(user); lastPayload.delete(user); }
+  });
 });
 
 /* theme config (no auth; recommend gating via Caddy) */
-app.get('/api/config', (_req, res) => res.json(cfg.theme));
-app.put('/api/config', (req, res) => {
+app.get(['/api/config', '/:user/api/config'], (_req, res) => res.json(cfg.theme));
+app.put(['/api/config', '/:user/api/config'], (req, res) => {
   const t = req.body || {};
   cfg.theme = { ...cfg.theme, ...t };
-  broadcast({ type: 'theme', payload: cfg.theme });
+  // broadcast theme to all users
+  for (const u of clients.keys()) broadcast(u, { type: 'theme', payload: cfg.theme });
   res.json(cfg.theme);
 });
 
@@ -115,8 +142,10 @@ app.put('/api/config', (req, res) => {
 app.get('/healthz', (_req, res) => res.json({ ok: true }));
 
 /* pages */
-app.get('/overlay', (_req, res) =>
-  res.sendFile(path.join(process.cwd(), 'server', 'public', 'overlay.html')));
+app.get(['/overlay', '/:user/overlay'], (req, res) => {
+  const user = resolveUser(req, res); if (!user) return;
+  res.sendFile(path.join(process.cwd(), 'server', 'public', 'overlay.html'));
+});
 
 app.get('/admin', (_req, res) =>
   res.sendFile(path.join(process.cwd(), 'server', 'public', 'admin.html')));

--- a/server/public/overlay.html
+++ b/server/public/overlay.html
@@ -42,14 +42,15 @@
   function animate(t){ if(!paused && runtimeSec>0){ if(lastT) positionSec+=(t-lastT)/1000; positionSec=Math.min(positionSec,runtimeSec); paint(); } lastT=t; requestAnimationFrame(animate); }
   requestAnimationFrame(animate);
 
+  const qs=location.search||'';
   async function loadTheme(){ try{
-    const t=await (await fetch('/api/config',{cache:'no-store'})).json();
+    const t=await (await fetch('api/config'+qs,{cache:'no-store'})).json();
     document.documentElement.style.setProperty('--accent',t.accent||'#ff3b30');
     document.documentElement.style.setProperty('--accent2',t.accent2||'#ff6b6b');
     document.documentElement.style.setProperty('--accent3',t.accent3||'#ff9a8b');
   }catch{} } loadTheme();
 
-  const es=new EventSource('/api/nowplaying/stream');
+  const es=new EventSource('api/nowplaying/stream'+qs);
   es.onmessage=(e)=>{ try{
     const {type,payload}=JSON.parse(e.data);
     if(type==='nowplaying'){


### PR DESCRIPTION
## Summary
- support per-user overlay URLs with optional HMAC signing and per-user SSE streams
- document new SIGN_KEY variable and per-user URLs across README and Caddy sample
- update bootstrap script to emit new env vars and server code

## Testing
- `npm --prefix server test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5d9fa6ce483268cc0261e09a27638