### PR TITLE
Send initial now playing update

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -132,7 +132,21 @@ app.get('/api/nowplaying/stream', (req, res) => {
   res.write('retry: 1000\n\n');
   clients.add(res);
 
+  res.write(`data: ${JSON.stringify({ type: 'theme', payload: cfg.theme })}\n\n`);
+
   let lastPayload = '';
+  fetchNowPlayingFor(info)
+    .then(cur => {
+      const serialized = JSON.stringify({ type: 'nowplaying', payload: cur });
+      lastPayload = serialized;
+      res.write(`data: ${serialized}\n\n`);
+    })
+    .catch(e => {
+      res.write(
+        `data: ${JSON.stringify({ type: 'error', message: e.message })}\n\n`
+      );
+    });
+
   const timer = every(cfg.pollMs, async () => {
     try {
       const cur = await fetchNowPlayingFor(info);
@@ -142,7 +156,9 @@ app.get('/api/nowplaying/stream', (req, res) => {
         res.write(`data: ${serialized}\n\n`);
       }
     } catch (e) {
-      res.write(`data: ${JSON.stringify({ type: 'error', message: e.message })}\n\n`);
+      res.write(
+        `data: ${JSON.stringify({ type: 'error', message: e.message })}\n\n`
+      );
     }
   });
 


### PR DESCRIPTION
## Summary
- push current theme to stream clients
- emit an initial now-playing payload before polling

## Testing
- `cd server && npm test >/tmp/unit.log && tail -n 20 /tmp/unit.log`


------
https://chatgpt.com/codex/tasks/task_e_68c5de2283ac83268917f31e7795871c