### PR TITLE
feat(server): per-user overlays with allowlist and optional URL signatures

### DIFF
--- a/server/.env.example
+++ b/server/.env.example
@@ -3,12 +3,7 @@ PORT=8080
 # Jellyfin connection (server-side only)
 JF_BASE=https://YOUR-JELLYFIN-URL
 JF_TOKEN=YOUR_API_KEY
-JF_USER=your_username
 JF_CLIENT=Jellyfin Media Player
-JF_DEVICE=
-JF_USERS_ALLOW=kenbee,alice,bob
-# HMAC key used to sign overlay requests; leave empty to disable
-OVERLAY_SIGNING_KEY=
 POLL_MS=1200
 
 # Theme: New Neon Edition
@@ -18,8 +13,7 @@ THEME_ACCENT3=#ff9a8b
 LABEL_NOW=NOW PLAYING
 LABEL_PAUSE=PAUSED
 
-# Comma-separated Jellyfin usernames allowed to use the overlay
+# Community mode (multi-user)
 JF_USERS_ALLOW=kenbee
-
-# Optional HMAC key; if set, URLs must include sig=HMAC_SHA256(user,key)
+# Optional: protect overlay URLs with signatures (HMAC-SHA256 of 'user' using this key)
 OVERLAY_SIGNING_KEY=


### PR DESCRIPTION
## Summary
- add community-mode settings for allowed users and optional overlay signatures
- enforce allowlist and HMAC validation for overlay requests
- make now playing API user-aware and expose errors properly

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5dfcf4bd083269c9a01599db74d6d