### PR TITLE
docs: document community overlay env variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ JF_USERS_ALLOW=kenbee
 OVERLAY_SIGNING_KEY=
 ```
 
-* `JF_USERS_ALLOW` — comma-separated Jellyfin usernames allowed to use the overlay.
-* `OVERLAY_SIGNING_KEY` — optional HMAC key; if set, URLs must include `sig=HMAC_SHA256(user,key)`.
+* `JF_USERS_ALLOW` — comma-separated Jellyfin usernames allowed to use `/overlay`.
+* `OVERLAY_SIGNING_KEY` — optional key for URL signatures; if set, `/overlay` and `/api/nowplaying` require `?sig=<hmac>` (`HMAC_SHA256(user,key)`).
 
 ## How it works
 

--- a/server/.env.example
+++ b/server/.env.example
@@ -13,7 +13,10 @@ THEME_ACCENT3=#ff9a8b
 LABEL_NOW=NOW PLAYING
 LABEL_PAUSE=PAUSED
 
-# Community mode (multi-user)
+# Community mode (multi-user overlays)
+# Only these Jellyfin usernames are allowed to use /overlay
 JF_USERS_ALLOW=kenbee
-# Optional: protect overlay URLs with signatures (HMAC-SHA256 of 'user' using this key)
+
+# Optional: protect overlay URLs with signatures (HMAC-SHA256 of 'user')
+# If set, /overlay and /api/nowplaying endpoints require ?sig=<hmac>
 OVERLAY_SIGNING_KEY=


### PR DESCRIPTION
## Summary
- explain JF_USERS_ALLOW for restricting overlay usage
- add optional OVERLAY_SIGNING_KEY for HMAC-signed overlay URLs

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68c5fbf0e44883269bfff92f48f18c53