### PR TITLE
docs(caddy): protect /admin with optional basic auth

### DIFF
--- a/caddy/Caddyfile.sample
+++ b/caddy/Caddyfile.sample
@@ -5,5 +5,10 @@ overlay.yourdomain.tld {
     # helpful for overlays & SSE
     Cache-Control "no-store"
   }
+  @admin path /admin*
+  # optional admin gate; create hash with: caddy hash-password --plaintext 'yourpw'
+  basicauth @admin {
+    admin JDJhJDEwJ...   # replace with your hash
+  }
   reverse_proxy 127.0.0.1:8080
 }


### PR DESCRIPTION
## Summary
- document optional basic auth guard for admin in Caddyfile sample

## Testing
- `npm test` (fails: Missing script: "test")
- `caddy validate --config caddy/Caddyfile.sample` (fails: command not found)


------
https://chatgpt.com/codex/tasks/task_e_68c6f9ef2e7c83268d9efc792688a45c